### PR TITLE
Refactor book layout in main

### DIFF
--- a/src/components/Book/Book.css
+++ b/src/components/Book/Book.css
@@ -1,44 +1,70 @@
 .book {
   display: flex;
-  flex-direction: column;
-  height: 100%;
-  padding: 10px;
-  justify-content: center;
-  align-items: center;
+  width: 90%;
+  justify-content: space-between;
+  background-color: #57C5B6;
+  border: 1px solid transparent;
+  border-radius: 10px;
   margin: 10px 0;
+  padding: 10px 20px;
+  box-shadow: 2px 2px 5px rgb(145, 142, 142);
 }
 
 .book-cover {
-  width: 250px;
+  width: 400px;
   height: auto;
-  border-top: 5px solid transparent;
-  border-bottom: 5px solid transparent;
 }
 
-.book-cover:hover {
+/* .book-cover:hover {
   border-top: 5px solid rgb(238, 200, 62);
   border-bottom: 5px solid rgb(238, 200, 62);
   cursor: pointer;
+} */
+
+.book-info {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  width: 60%;
+  font-size: 20px;
+}
+
+.book-info-header {
+  display: flex;
+  justify-content: space-between;
+  font-family: 'Playfair Display SC', serif;
+}
+
+.book-info-details {
+  display: flex;
+  justify-content: space-between;
+  flex-direction: column;
+  font-size: 25px;
+  padding: 20px;
+  background-color: #159895;
+  border-radius: 10px;
 }
 
 .title {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  font-family: 'Playfair Display SC', serif;
-  font-size: 14px;
+  font-size: 50px;
+  margin: 0;
+  margin-top: 40px
+}
+
+.author {
+  font-size: 30px;
+  margin: 0
 }
 
 .heart {
-  height: 30px;
-  fill: white;
+  height: 65px;
   transition-duration: 200ms;
-  margin-right: 15px
+  color: rgb(233, 83, 83);
+  filter: invert(30%) sepia(17%) saturate(4983%) hue-rotate(332deg) brightness(128%) contrast(94%);
 }
 
 .heart:hover {
-  transform: scale(1.4);
+  transform: scale(1.1);
   cursor: pointer;
 }
 

--- a/src/components/Book/Book.js
+++ b/src/components/Book/Book.js
@@ -4,7 +4,20 @@ import './Book.css'
 import heart from '../assets/images/heart-regular.svg'
 import fillHeart from '../assets/images/heart-solid.svg'
 
-const Book = ({ book_id, name, cover, url, genre, liked, addToFavorites, removeFromFavorites, handleModalState }) => {
+const Book = ({
+  book_id,
+  title,
+  author,
+  cover,
+  url,
+  genre,
+  liked,
+  addToFavorites,
+  removeFromFavorites,
+  handleModalState,
+  rank,
+  weeks_on_list,
+  description }) => {
 
   const [isFavorite, setIsFavorite] = useState(liked)
 
@@ -13,7 +26,7 @@ const Book = ({ book_id, name, cover, url, genre, liked, addToFavorites, removeF
   }
 
   const likeBook = <Book
-    name={name}
+    title={title}
     cover={cover}
     url={url}
     key={book_id}
@@ -26,7 +39,7 @@ const Book = ({ book_id, name, cover, url, genre, liked, addToFavorites, removeF
   />
 
   const unlikeBook = <Book
-    name={name}
+    title={title}
     cover={cover}
     url={url}
     key={book_id}
@@ -57,10 +70,22 @@ const Book = ({ book_id, name, cover, url, genre, liked, addToFavorites, removeF
 
   return (
     <div className='book'>
-      <img alt={`Cover of ${name}`} src={`${cover}`} className="book-cover" onClick={() => handleModalState(book_id)} />
-      <div className='title'>
-        {isFavorite === true ? favorite : unFavorite}
-        <p className='name'>{name}</p>
+      <img alt={`Cover of ${title}`} src={`${cover}`} className="book-cover" onClick={() => handleModalState(book_id)} />
+      <div className='book-info'>
+        <div className='book-info-header'>
+          <div className='title-author'>
+            <p>{genre}</p>
+            <h1 className='title'>{title}</h1>
+            <p className='author'>{author}</p>
+          </div>
+          {isFavorite === true ? favorite : unFavorite}
+        </div>
+        <div className='book-info-details'>
+          <p className='description'>{description}</p>
+          <p className='rank'>This week's rank: #{rank}</p>
+          <p className='weeks-on-list'>Weeks on this list: {weeks_on_list}</p>
+          <a href={url} className='url'>More Info & Purchase Options</a>
+        </div>
       </div>
     </div>
   )

--- a/src/components/Home/Home.css
+++ b/src/components/Home/Home.css
@@ -32,6 +32,7 @@
 
 .genre {
   display: flex;
+  flex-direction: column;
   width: 98%;
   height: 100%;
   margin-bottom: 0;

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -29,9 +29,10 @@ const Home = ({ books, showModal, handleModalState, bookDetails, isLoading, clea
   if (books.length) {
     let booksToDisplay = books.map((book, idx) =>
       <Book
-        name={book.title}
+        title={book.title}
         cover={book.book_image}
         url={book.amazon_product_url}
+        author={book.contributor}
         key={idx}
         rank={book.rank}
         genre={genreSelection}

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,7 @@
 body {
   margin: 0;
+  background-color: #0f4684;
+  color: white;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;


### PR DESCRIPTION
#### What's this PR do?
This merge will:
- Incorporate changes being fetched from the API as described in the previous PR #28 
- Redesign book in the home page to show all details without clicking on the book component
#### Where should the reviewer start?
- Assuming the user has cloned the repo to their local machine, run `npm i` to install all dependencies, followed by `git fetch` to make sure all changes from the repo are current.
- Run `npm start` which will start the local production server, opening in a browser automatically.
#### How should this be manually tested?
Looking at the code, notice the API has been changed. Testing the application, notice the significant overhaul to the main homepage.
*NOTE*: Do not navigate to the library or search sections, as breaking changes have not been fixed for those components yet.
#### Any background context you want to provide?
The old API (HAPI Books) had a very small call quota, and required monthly payment for more data. This was not working for the frequency and the amount of calls being made to the API.
#### Screenshots (if appropriate)
<img width="1416" alt="image" src="https://user-images.githubusercontent.com/74210902/229162329-a0a0d7a8-81af-443f-814d-86a1260e402c.png">
