### PR TITLE
Add liked books to my library

### DIFF
--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -34,6 +34,21 @@ const getAwardedBooks = (year) => {
 
 export { getBooks, getBookById, getAwardedBooks }
 
+let genreNames = [
+  "humor",
+  "science",
+  "health",
+  "food-and-fitness",
+  "education",
+  "business-books",
+  "culture",
+  "celebrities",
+  "advice-how-to-and-miscellaneous",
+  "hardcover-nonfiction",
+  "hardcover-fiction",
+  "picture-books"
+]
+
 /*
 EXAMPLE BOOK SET
 "books": [

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -24,17 +24,7 @@ const reducer = (state, action) => {
     case "SUCCESS":
       return { ...state, isLoading: false, books: action.payload.books }
     case "FAVORITE":
-      let genre = action.payload.genre
-      if (!genre) {
-        return { ...state, isLoading: false, myLibrary: [...state.myLibrary, action.payload.newBook] }
-      } else {
-        let id = action.payload.id
-        let newBook = action.payload.newBook
-        let genreList = [...state.books[genre]]
-        let index = genreList.findIndex(book => book.props.book_id === id)
-        genreList[index] = newBook
-        return { ...state, isLoading: false, books: { ...state.books, [genre]: genreList }, myLibrary: [...state.myLibrary, newBook] }
-      }
+      return { ...state, books: action.payload.books, myLibrary: [...state.myLibrary, action.payload.favorite] }
     case "UNFAVORITE":
       let library = state.myLibrary.filter(book => book.props.book_id !== action.payload.id)
       if (!action.payload.genre) {
@@ -71,33 +61,12 @@ const App = () => {
 
   const [state, dispatch] = useReducer(reducer, initialState)
 
-  let genreNames = ["humor", "science", "health", "food-and-fitness", "education", "business-books", "culture", "celebrities", "advice-how-to-and-miscellaneous", "paperback-nonfiction", "hardcover-nonfiction", "hardcover-fiction", "picture-books"]
-
   const getIt = async (genre) => {
     await getBooks(genre)
       .then((data) => {
         dispatch({ type: "SUCCESS", payload: { books: data.results.books, genre: "fiction" } })
       })
   }
-
-  // const formatBooks = (booksByGenre, genre) => {
-  //   let books = booksByGenre.map((book, idx) =>
-  //     <Book
-  //       name={book.title}
-  //       cover={book.book_image}
-  //       url={book.amazon_product_url}
-  //       key={idx}
-  //       rank={book.rank}
-  //       genre={genre}
-  //       weeks_on_list={book.weeks_on_list}
-  //       description={book.description}
-  //       liked={false}
-  //       addToFavorites={addToFavorites}
-  //       removeFromFavorites={removeFromFavorites}
-  //       handleModalState={handleModalState}
-  //     />)
-  //   return books
-  // }
 
   const checkForFavorite = (searchedBooks) => {
     let libraryBooks = state.myLibrary.map(book => book.props.book_id)
@@ -123,12 +92,22 @@ const App = () => {
     })
   }
 
-  const removeFromFavorites = (id, genre, newBook) => {
-    dispatch({ type: "UNFAVORITE", payload: { id: id, genre: genre, newBook: newBook } })
+  const removeFromFavorites = (isbn) => {
+
+    dispatch({ type: "UNFAVORITE", payload: "nothing" })
   }
 
-  const addToFavorites = (id, genre, newBook) => {
-    dispatch({ type: "FAVORITE", payload: { id: id, genre: genre, newBook: newBook } })
+  const addToFavorites = (isbn) => {
+    let books = [...state.books]
+    let favorite
+    books.map(book => {
+      if (book.primary_isbn13 === isbn) {
+        book.isFavorite = true
+        favorite = book
+        return book
+      } else { return book }
+    })
+    dispatch({ type: "FAVORITE", payload: { books: books, favorite: favorite } })
   }
 
   const handleModalState = (id) => {
@@ -162,6 +141,7 @@ const App = () => {
     dispatch({ type: "CLEAR" })
   }
 
+  console.log(state.myLibrary)
   return (
     <Routes>
       <Route

--- a/src/components/Book/Book.css
+++ b/src/components/Book/Book.css
@@ -33,13 +33,14 @@
   display: flex;
   justify-content: space-between;
   font-family: 'Playfair Display SC', serif;
+  margin-bottom: 40px;
 }
 
 .book-info-details {
   display: flex;
   justify-content: space-between;
   flex-direction: column;
-  font-size: 25px;
+  font-size: 22px;
   padding: 20px;
   background-color: #159895;
   border-radius: 10px;
@@ -54,6 +55,30 @@
 .author {
   font-size: 30px;
   margin: 0
+}
+
+.rank-info {
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+}
+
+.rank,
+.weeks-on-list {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #002B5B;
+  border-radius: 50%;
+  width: 80px;
+  height: 80px;
+  padding: 5px;
+  font-weight: 600;
+  font-size: 30px;
+}
+
+.url {
+  font-size: 15px;
 }
 
 .heart {

--- a/src/components/Book/Book.js
+++ b/src/components/Book/Book.js
@@ -10,8 +10,9 @@ const Book = ({
   author,
   cover,
   url,
+  isbn,
   genre,
-  liked,
+  isFavorite,
   addToFavorites,
   removeFromFavorites,
   handleModalState,
@@ -19,43 +20,11 @@ const Book = ({
   weeks_on_list,
   description }) => {
 
-  const [isFavorite, setIsFavorite] = useState(liked)
-
-  const handleChange = () => {
-    isFavorite === true ? setIsFavorite(false) : setIsFavorite(true)
-  }
-
-  const likeBook = <Book
-    title={title}
-    cover={cover}
-    url={url}
-    key={book_id}
-    book_id={book_id}
-    addToFavorites={addToFavorites}
-    removeFromFavorites={removeFromFavorites}
-    handleModalState={handleModalState}
-    genre={genre}
-    liked={true}
-  />
-
-  const unlikeBook = <Book
-    title={title}
-    cover={cover}
-    url={url}
-    key={book_id}
-    book_id={book_id}
-    addToFavorites={addToFavorites}
-    removeFromFavorites={removeFromFavorites}
-    genre={genre}
-    liked={false}
-  />
-
   const favorite = <img src={fillHeart}
     alt="favorite icon"
     className='heart'
     onClick={() => {
-      handleChange()
-      removeFromFavorites(book_id, genre, unlikeBook)
+      removeFromFavorites(isbn)
     }}
   />
 
@@ -63,8 +32,7 @@ const Book = ({
     alt="favorite icon"
     className='heart'
     onClick={() => {
-      handleChange()
-      addToFavorites(book_id, genre, likeBook)
+      addToFavorites(isbn)
     }}
   />
 
@@ -78,13 +46,17 @@ const Book = ({
             <h1 className='title'>{title}</h1>
             <p className='author'>{author}</p>
           </div>
-          {isFavorite === true ? favorite : unFavorite}
+          {isFavorite ? favorite : unFavorite}
         </div>
         <div className='book-info-details'>
           <p className='description'>{description}</p>
-          <p className='rank'>This week's rank: #{rank}</p>
-          <p className='weeks-on-list'>Weeks on this list: {weeks_on_list}</p>
-          <a href={url} className='url'>More Info & Purchase Options</a>
+          <div className='rank-info'>
+            <p style={{ textDecoration: 'underline' }}>Rank</p>
+            <p className='rank'>#{rank}</p>
+            <p style={{ textDecoration: 'underline' }}>Consecutive Weeks</p>
+            <p className='weeks-on-list'>{weeks_on_list}</p>
+          </div>
+          <a href={url} className='url' target="_blank" rel="noopener noreferrer">More Info & Purchase Options</a>
         </div>
       </div>
     </div>

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -34,11 +34,12 @@ const Home = ({ books, showModal, handleModalState, bookDetails, isLoading, clea
         url={book.amazon_product_url}
         author={book.contributor}
         key={idx}
+        isbn={book.primary_isbn13}
         rank={book.rank}
-        genre={genreSelection}
+        genre={displayGenre}
         weeks_on_list={book.weeks_on_list}
         description={book.description}
-        liked={false}
+        isFavorite={book.isFavorite}
         addToFavorites={addToFavorites}
         removeFromFavorites={removeFromFavorites}
         handleModalState={handleModalState}
@@ -56,6 +57,8 @@ const Home = ({ books, showModal, handleModalState, bookDetails, isLoading, clea
         <option value='food-and-fitness'>Food & Fitness</option>
         <option value='celebrities'>Celebrities</option>
         <option value='culture'>Culture</option>
+        <option value='advice-how-to-and-miscellaneous'>Adivce & How-To</option>
+        <option value='picture-books'>Picture Books</option>
       </select>
 
     return (

--- a/src/components/MyLibrary/MyLibrary.js
+++ b/src/components/MyLibrary/MyLibrary.js
@@ -26,13 +26,13 @@ const MyLibrary = ({ myLibrary, showModal, handleModalState, bookDetails, isLoad
   )
 }
 
-MyLibrary.propTypes = {
-  myLibrary: PropTypes.arrayOf(PropTypes.elementType).isRequired,
-  handleModalState: PropTypes.func.isRequired,
-  clearSearch: PropTypes.func.isRequired,
-  showModal: PropTypes.bool.isRequired,
-  isLoading: PropTypes.bool.isRequired,
-  bookDetails: PropTypes.object,
-}
+// MyLibrary.propTypes = {
+//   myLibrary: PropTypes.arrayOf(PropTypes.elementType).isRequired,
+//   handleModalState: PropTypes.func.isRequired,
+//   clearSearch: PropTypes.func.isRequired,
+//   showModal: PropTypes.bool.isRequired,
+//   isLoading: PropTypes.bool.isRequired,
+//   bookDetails: PropTypes.object,
+// }
 
 export default MyLibrary


### PR DESCRIPTION
#### What's this PR do?
This merge will...
- Incorporate "liking" functionality for each book in the home page. The book will be added to the user's favorites list when the heart is clicked.
- Cannot yet navigate to My Library. See note below.
#### Where should the reviewer start?
- Assuming the user has cloned the repo to their local machine, run `npm i` to install all dependencies, followed by `git fetch` to make sure all changes from the repo are current.
- Run `npm start` which will start the local production server, opening in a browser automatically.
#### How should this be manually tested?
Looking at the code, notice the API has been changed. Testing the application, notice the significant overhaul to the main homepage.
*NOTE*: Do not navigate to the library or search sections, as breaking changes have not been fixed for those components yet.
#### Any background context you want to provide?
The old API (HAPI Books) had a very small call quota, and required monthly payment for more data. This was not working for the frequency and the amount of calls being made to the API.
#### Screenshots
<img width="1363" alt="image" src="https://user-images.githubusercontent.com/74210902/229163980-2bae9c1c-7978-447f-af36-ddd1ce599f59.png">

